### PR TITLE
Create simple GitHub pages

### DIFF
--- a/_CNAME
+++ b/_CNAME
@@ -1,0 +1,1 @@
+github.fans

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: "GitHub User Group"
+show_downloads: false

--- a/index.md
+++ b/index.md
@@ -1,0 +1,40 @@
+# GitHub User Group in Israel
+
+Monthly meetings about GitHub in Tel Aviv-Yafo, Israel.
+For more details check out our [Meetup page](https://www.meetup.com/github-user-group/).
+
+## Organizers
+
+* [Eyar Zilberman](https://www.linkedin.com/in/eyar-zilberman/)
+* [Dana Fine](https://www.linkedin.com/in/fine-dana/)
+* [Noaa Barki](https://www.linkedin.com/in/noaa-barki-159498163/)
+* [Shimon Tolts](https://www.linkedin.com/in/tolts/)
+
+## Co-organizers
+
+* [Ronen Levinson](https://www.linkedin.com/in/ronen-levinson/)
+
+# Upcoming events
+
+## [next](https://www.meetup.com/github-user-group/)
+
+-----------------------------
+# Past events
+
+## 2023.06.25 - [Tracing the Open Source Revolution & Tracing the Git Revolution](https://www.meetup.com/github-user-group/events/293909064/)
+
+* Tracing the Open Source Revolution by [Tomer Brisker](https://www.linkedin.com/in/tbrisker/) (Principal Software Engineer & Tech Lead @ [Red Hat](https://www.redhat.com/))
+* Tracing the Git Revolution by [Shalev Avhar](https://www.linkedin.com/in/shalev-avhar-750818164/) (Software Developer @ [Datree](https://www.datree.io/))
+
+### Sponsors:
+
+* [Couchbase](https://www.couchbase.com/) - NoSQL Cloud Database Service
+* [Outshift by Cisco](https://eti.cisco.com/)
+
+
+## 2019.09.24 - [Automated Git workflow & How Rookout enforces good dev practices](https://www.meetup.com/github-user-group/events/264489604/)
+
+* Automated git workflow: Github Probot VS Github Actions by [Ronen Levinson](https://www.linkedin.com/in/ronen-levinson/), DevOps Engineer @ [CodeValue](https://codevalue.com/) - [slides](Meetup #3/Automated git workflow: Github Probot VS Github Actions.pdf)
+* GitEnforcer - how Rookout enforces good dev practices on GitHub by [Mickael Alliel](https://www.linkedin.com/in/mickaelalliel/), DevOps/Full Stack Developer @ [Rookout](https://www.rookout.com/) - [slides](Meetup #3/GitEnforcer - how Rookout enforces good dev practices on GitHub.pdf)
+
+


### PR DESCRIPTION
In order to enable the site

* Go to settings / pages ; set Deploy from branch, select 'master' as the branch and (root).
* To make  the github.fans domain show this page two thing need to be done:
    * rename the _CNAME file to CNAME
    * At your DNS provider map github.fans to the A and AAAA sections as listed here: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site


For now the page can be seen here:  https://github.szabgab.com/GitHub-User-Group/

If you accept this I'll keep updating the page.